### PR TITLE
Fix typo to ensure both handles are set correctly for creating edges

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -28,7 +28,7 @@ where
 
     for link in gfa.links.iter() {
         let left = Handle::new(link.from_segment, link.from_orient);
-        let right = Handle::new(link.from_segment, link.from_orient);
+        let right = Handle::new(link.to_segment, link.to_orient);
         graph.create_edge(Edge(left, right));
     }
 


### PR DESCRIPTION
Fixes a small typo so that edges now get both handles assigned when parsing a GFA file.